### PR TITLE
Add mono-repo package.json scripts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,4 @@
 /**/*/.env
 /**/*/node_modules 
+
+node_modules/*

--- a/frontend/.eslintrc.json
+++ b/frontend/.eslintrc.json
@@ -59,6 +59,7 @@
             "prefer-double"
         ],
         "import/extensions": "off",
-        "react/jsx-props-no-spreading": "off"
+        "react/jsx-props-no-spreading": "off",
+        "react/function-component-definition": "off"
     }
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,27 @@
 {
-  "name": "cs3219-project-ay2223s1-g55",
+  "name": "team-project",
   "lockfileVersion": 2,
   "requires": true,
-  "packages": {}
+  "packages": {
+    "": {
+      "devDependencies": {
+        "@vercel/git-hooks": "^1.0.0"
+      }
+    },
+    "node_modules/@vercel/git-hooks": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@vercel/git-hooks/-/git-hooks-1.0.0.tgz",
+      "integrity": "sha512-OxDFAAdyiJ/H0b8zR9rFCu3BIb78LekBXOphOYG3snV4ULhKFX387pBPpqZ9HLiRTejBWBxYEahkw79tuIgdAA==",
+      "dev": true,
+      "hasInstallScript": true
+    }
+  },
+  "dependencies": {
+    "@vercel/git-hooks": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@vercel/git-hooks/-/git-hooks-1.0.0.tgz",
+      "integrity": "sha512-OxDFAAdyiJ/H0b8zR9rFCu3BIb78LekBXOphOYG3snV4ULhKFX387pBPpqZ9HLiRTejBWBxYEahkw79tuIgdAA==",
+      "dev": true
+    }
+  }
 }

--- a/package.json
+++ b/package.json
@@ -1,0 +1,11 @@
+{
+  "scripts": {
+    "frontend": "cd frontend && npm run dev",
+    "user": "cd user-service && npm run dev",
+    "matching": "cd matching-service && npm run dev",
+    "git-pre-commit": "cd frontend && npm run lint"
+  },
+  "devDependencies": {
+    "@vercel/git-hooks": "^1.0.0"
+  }
+}


### PR DESCRIPTION
Added pre-commit hook that runs lint on `/frontend`. Can be extended to run other command during pre-commit. For more info see: https://github.com/vercel/git-hooks

Also added 3 script commands: `npm run frontend`, `npm run user`, `npm run matching` to run the respective files from the root folder.