### PR TITLE
Ezek/graph endpoints

### DIFF
--- a/history-service/controller/record-controller.js
+++ b/history-service/controller/record-controller.js
@@ -65,18 +65,6 @@ export async function listUserRecords(req, res) {
   }
 }
 
-export async function getUserCompletedQuestionsCount(req, res) {
-  try {
-    const { username } = req.params;
-    const { group } = req.query;
-
-    const count = await _getUserCompletedQuestionsCount(username, { group });
-    return res.status(200).json(count);
-  } catch (err) {
-    return res.status(500).json({ message: 'Database failure when retrieving records.' });
-  }
-}
-
 export async function createRecord(req, res) {
   try {
     const body = req.body;

--- a/history-service/controller/record-controller.js
+++ b/history-service/controller/record-controller.js
@@ -3,7 +3,8 @@ import {
   ormCreateRecord as _createRecord,
   ormListUserCompletedQuestions as _listUserCompletedQuestions,
   ormGetUserExperienceLevel as _getUserExperienceLevel,
-  ormCountUserCompletedQuestions as _countUserCompletedQuestions
+  ormCountUserCompletedQuestionsByDifficulty as _countUserCompletedQuestionsByDifficulty,
+  ormCountUserCompletedQuestionsByMonth as _countUserCompletedQuestionsByMonth
 } from '../model/record-orm.js';
 import { validateRecord } from './validations.js';
 
@@ -33,7 +34,19 @@ export async function getUserCompletedDifficultiesCount(req, res) {
   try {
     const { username } = req.params;
 
-    const count = await _countUserCompletedQuestions(username, 'questionDifficulty');
+    const count = await _countUserCompletedQuestionsByDifficulty(username);
+    return res.status(200).json(count);
+  } catch (err) {
+    return res.status(500).json({ message: 'Database failure when retrieving user completed questions.' });
+  }
+}
+
+export async function getUserCompletedMonthlyCount(req, res) {
+  try {
+    const { username } = req.params;
+    const { limit } = req.query;
+
+    const count = await _countUserCompletedQuestionsByMonth(username, limit)
     return res.status(200).json(count);
   } catch (err) {
     return res.status(500).json({ message: 'Database failure when retrieving user completed questions.' });

--- a/history-service/controller/record-controller.js
+++ b/history-service/controller/record-controller.js
@@ -2,7 +2,8 @@ import {
   ormListUserRecords as _listUserRecords,
   ormCreateRecord as _createRecord,
   ormListUserCompletedQuestions as _listUserCompletedQuestions,
-  ormGetUserExperienceLevel as _getUserExperienceLevel
+  ormGetUserExperienceLevel as _getUserExperienceLevel,
+  ormCountUserCompletedQuestions as _countUserCompletedQuestions
 } from '../model/record-orm.js';
 import { validateRecord } from './validations.js';
 
@@ -28,6 +29,17 @@ export async function listUserCompletedQuestions(req, res) {
   }
 }
 
+export async function getUserCompletedDifficultiesCount(req, res) {
+  try {
+    const { username } = req.params;
+
+    const count = await _countUserCompletedQuestions(username, 'questionDifficulty');
+    return res.status(200).json(count);
+  } catch (err) {
+    return res.status(500).json({ message: 'Database failure when retrieving user completed questions.' });
+  }
+}
+
 export async function listUserRecords(req, res) {
   try {
     const { username } = req.params;
@@ -35,6 +47,18 @@ export async function listUserRecords(req, res) {
 
     const records = await _listUserRecords(username, { limit, offset });
     return res.status(200).json(records);
+  } catch (err) {
+    return res.status(500).json({ message: 'Database failure when retrieving records.' });
+  }
+}
+
+export async function getUserCompletedQuestionsCount(req, res) {
+  try {
+    const { username } = req.params;
+    const { group } = req.query;
+
+    const count = await _getUserCompletedQuestionsCount(username, { group });
+    return res.status(200).json(count);
   } catch (err) {
     return res.status(500).json({ message: 'Database failure when retrieving records.' });
   }

--- a/history-service/index.js
+++ b/history-service/index.js
@@ -10,7 +10,8 @@ import {
   listUserRecords,
   createRecord,
   listUserCompletedQuestions,
-  getUserExperienceLevel
+  getUserExperienceLevel,
+  getUserCompletedDifficultiesCount
 } from './controller/record-controller.js';
 
 const router = express.Router();
@@ -20,6 +21,7 @@ router.get('/', (_, res) => res.send('History-service is up and running!'));
 router.get('/records/:username', listUserRecords);
 router.post('/records/:username', createRecord);
 router.get('/completed/:username', listUserCompletedQuestions);
+router.get('/completed/difficultyCount/:username', getUserCompletedDifficultiesCount);
 router.get('/experience/:username', getUserExperienceLevel);
 
 app.use('/api/history', router).all((_, res) => {

--- a/history-service/index.js
+++ b/history-service/index.js
@@ -11,7 +11,8 @@ import {
   createRecord,
   listUserCompletedQuestions,
   getUserExperienceLevel,
-  getUserCompletedDifficultiesCount
+  getUserCompletedDifficultiesCount,
+  getUserCompletedMonthlyCount
 } from './controller/record-controller.js';
 
 const router = express.Router();
@@ -22,6 +23,7 @@ router.get('/records/:username', listUserRecords);
 router.post('/records/:username', createRecord);
 router.get('/completed/:username', listUserCompletedQuestions);
 router.get('/completed/difficultyCount/:username', getUserCompletedDifficultiesCount);
+router.get('/completed/monthCount/:username', getUserCompletedMonthlyCount);
 router.get('/experience/:username', getUserExperienceLevel);
 
 app.use('/api/history', router).all((_, res) => {

--- a/history-service/model/record-orm.js
+++ b/history-service/model/record-orm.js
@@ -2,7 +2,8 @@ import {
   listUserRecords,
   createRecord,
   listUserCompletedQuestions,
-  getUserExperienceLevel
+  getUserExperienceLevel,
+  countUserCompletedQuestions
 } from './repository.js';
 
 export async function ormGetUserExperienceLevel(username) {
@@ -19,6 +20,16 @@ export async function ormListUserCompletedQuestions(username) {
   try {
     const questions = await listUserCompletedQuestions(username);
     return questions;
+  } catch (err) {
+    console.error("Failed to get questions");
+    return { err }
+  }
+}
+
+export async function ormCountUserCompletedQuestions(username, groupBy) {
+  try {
+    const count = await countUserCompletedQuestions(username, groupBy);
+    return count;
   } catch (err) {
     console.error("Failed to get questions");
     return { err }

--- a/history-service/model/record-orm.js
+++ b/history-service/model/record-orm.js
@@ -3,7 +3,8 @@ import {
   createRecord,
   listUserCompletedQuestions,
   getUserExperienceLevel,
-  countUserCompletedQuestions
+  countUserCompletedQuestionsByDifficulty,
+  countUserCompletedQuestionsByMonth
 } from './repository.js';
 
 export async function ormGetUserExperienceLevel(username) {
@@ -26,12 +27,22 @@ export async function ormListUserCompletedQuestions(username) {
   }
 }
 
-export async function ormCountUserCompletedQuestions(username, groupBy) {
+export async function ormCountUserCompletedQuestionsByDifficulty(username) {
   try {
-    const count = await countUserCompletedQuestions(username, groupBy);
+    const count = await countUserCompletedQuestionsByDifficulty(username);
     return count;
   } catch (err) {
-    console.error("Failed to get questions");
+    console.error("Failed to get count");
+    return { err }
+  }
+}
+
+export async function ormCountUserCompletedQuestionsByMonth(username, limit) {
+  try {
+    const count = await countUserCompletedQuestionsByMonth(username, limit);
+    return count;
+  } catch (err) {
+    console.error("Failed to get count")
     return { err }
   }
 }

--- a/history-service/model/repository.js
+++ b/history-service/model/repository.js
@@ -83,7 +83,7 @@ export async function countUserCompletedQuestionsByMonth(username, limit = 12) {
 }
 
 export async function countUserCompletedQuestionsByDifficulty(username) {
-  return await RecordModel.aggregate([
+  const counts = await RecordModel.aggregate([
     {
       $match: {
         $or: [{ firstUsername: username }, { secondUsername: username }]
@@ -94,12 +94,12 @@ export async function countUserCompletedQuestionsByDifficulty(username) {
         _id: `$questionDifficulty`,
         count: { $sum: 1 }
       }
-    },
-    {
-      $project: {
-        difficulty: '$_id',
-        count: '$count'
-      }
     }
   ])
+  return counts.reduce((result, difficultyCount) => {
+    return {
+      ...result,
+      [`${difficultyCount._id}`]: difficultyCount.count
+    }
+  }, {})
 }

--- a/history-service/model/repository.js
+++ b/history-service/model/repository.js
@@ -58,3 +58,25 @@ export async function listUserCompletedQuestions(username) {
   return await RecordModel
     .distinct('questionName', { $or: [{ firstUsername: username }, { secondUsername: username }] })
 }
+
+export async function countUserCompletedQuestions(username, groupBy) {
+  return await RecordModel.aggregate([
+    {
+      $match: {
+        $or: [{ firstUsername: username }, { secondUsername: username }]
+      }
+    },
+    {
+      $group: {
+        _id: `$${groupBy}`,
+        count: { $sum: 1 }
+      }
+    },
+    {
+      $project: {
+        difficulty: '$_id',
+        count: '$count'
+      }
+    }
+  ])
+}

--- a/history-service/model/repository.js
+++ b/history-service/model/repository.js
@@ -78,7 +78,7 @@ export async function countUserCompletedQuestionsByMonth(username, limit = 12) {
       }
     },
     { $sort: { _id: -1 } }, // Descending order, we want the latest counts
-    { $limit: limit } // Limit number of months to retrieve
+    { $limit: +limit } // Limit number of months to retrieve
   ])
 }
 


### PR DESCRIPTION
```node
/*
Limit is an optional field to get the latest "limit' number of monthly counts. For example, limit = 3 will get 
the last 3 months where the user was actively clocking completed questions. For months that user did 
not complete any question, it will _not_ be counted into the 'limit'. We will skip the month and get the 
last month where the user did complete some question, if any such months exist. 
Limit = 12 by default.

returns: {
  month: number; // eg: 11, where 11 is november
  year: number; // eg: 2022
  count: number;
}[]
*/
/api/history/completed/monthCount/:username(?limit=number)

/*
If count = 0, we don't return anything.

returns: {
  Easy: number | undefined;
  Medium: number | undefined;
  Hard: number | undefined;
}
*/
/api/history/completed/difficultyCount/:username
```